### PR TITLE
Style fixes

### DIFF
--- a/web/src/components/NewsLetterSignUp/NewsLetterSignUp.module.scss
+++ b/web/src/components/NewsLetterSignUp/NewsLetterSignUp.module.scss
@@ -1,3 +1,3 @@
-.signup-cta {
+.signupCta {
   text-wrap: wrap;
 }

--- a/web/src/components/NewsLetterSignUp/NewsLetterSignup.tsx
+++ b/web/src/components/NewsLetterSignUp/NewsLetterSignup.tsx
@@ -10,7 +10,7 @@ export const NewsLetterSignup = (): React.ReactElement => {
 		<Button
 			elementType="a"
 			variant="cta"
-			className={styles["signup-cta"]}
+			className={styles.signupCta}
 			href="https://www.nice.org.uk/news/nice-newsletters-and-alerts"
 		>
 			Sign up for newsletters and alerts

--- a/web/src/components/Storyblok/NewsPageHeader/NewsPageHeaderFooter/NewsPageHeaderFooter.module.scss
+++ b/web/src/components/Storyblok/NewsPageHeader/NewsPageHeaderFooter/NewsPageHeaderFooter.module.scss
@@ -1,7 +1,7 @@
 @use '@nice-digital/nds-core/scss/spacing';
 @use '@nice-digital/nds-core/scss/utils';
 
-.page-header-footer {
+.footer {
   display: flex;
   gap: utils.rem(spacing.$medium);
 }

--- a/web/src/components/Storyblok/NewsPageHeader/NewsPageHeaderFooter/NewsPageHeaderFooter.tsx
+++ b/web/src/components/Storyblok/NewsPageHeader/NewsPageHeaderFooter/NewsPageHeaderFooter.tsx
@@ -32,7 +32,7 @@ export const NewsPageHeaderFooter: React.FC<NewsPageHeaderFooterProps> = ({
 	}
 
 	return (
-		<div className={styles["page-header-footer"]}>
+		<div className={styles.footer}>
 			<Tag outline data-testid="pageTag">
 				{tagValue}
 			</Tag>

--- a/web/src/components/Storyblok/StoryblokAuthor/AuthorList/AuthorList.module.scss
+++ b/web/src/components/Storyblok/StoryblokAuthor/AuthorList/AuthorList.module.scss
@@ -5,16 +5,14 @@
 @use '@nice-digital/nds-core/scss/utils';
 
 
-.author-list {
-
+.authorList {
   //TODO: remove secondsection styles in NDS. Manage authorlist style in this component
   @include media-queries.mq($from: md) {
     padding-bottom: utils.rem(spacing.$x-large);
   }
+}
 
-  &__heading {
-    @include typography.h6;
-    margin: 0 0 utils.rem(spacing.$small);
-  }
-
+.heading {
+  @include typography.h6;
+  margin: 0 0 utils.rem(spacing.$small);
 }

--- a/web/src/components/Storyblok/StoryblokAuthor/AuthorList/AuthorList.tsx
+++ b/web/src/components/Storyblok/StoryblokAuthor/AuthorList/AuthorList.tsx
@@ -35,8 +35,8 @@ export const AuthorList = ({
 
 	if (authors.length > 1) {
 		return (
-			<div className={styles["author-list"]}>
-				<h3 className={styles["author-list__heading"]}>List of authors</h3>
+			<div className={styles.authorList}>
+				<h3 className={styles.heading}>List of authors</h3>
 				{authors.map((author) => {
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
 					const { image, ...contentWithoutImage } = author.content;

--- a/web/src/components/Storyblok/StoryblokBlogPost/StoryblokBlogPost.module.scss
+++ b/web/src/components/Storyblok/StoryblokBlogPost/StoryblokBlogPost.module.scss
@@ -2,9 +2,10 @@
 @use '@nice-digital/nds-core/scss/spacing';
 @use '@nice-digital/nds-core/scss/utils';
 
+/* stylelint-disable selector-class-pattern */
 
 .newsSectionArticle {
-  // set up variables for the offset of the featured image across breakpoints
+
   --featuredImageOffset: 16dvh;
 
   // set padding on page-header based on the image offset

--- a/web/src/components/Storyblok/StoryblokNewsArticle/StoryblokNewsArticle.module.scss
+++ b/web/src/components/Storyblok/StoryblokNewsArticle/StoryblokNewsArticle.module.scss
@@ -2,6 +2,7 @@
 @use '@nice-digital/nds-core/scss/spacing';
 @use '@nice-digital/nds-core/scss/utils';
 
+/* stylelint-disable selector-class-pattern */
 
 .newsSectionArticle {
   // set up variables for the offset of the featured image across breakpoints
@@ -50,22 +51,7 @@
     }
   }
 
-  .articleSidebar {
-    margin: utils.rem(spacing.$large) 0 0;
 
-    @include media-queries.mq($from: md) {
-      margin: 0 0 utils.rem(spacing.$large);
-    }
-
-    //override child panel margins
-    & > * + * {
-      margin: 2rem 0 0;
-    }
-
-    & > :last-child {
-      margin-bottom: 0;
-    }
-  }
 
   hr {
     margin: utils.rem(spacing.$medium 0);
@@ -77,3 +63,15 @@
 
 }
 
+.articleSidebar {
+  margin: utils.rem(spacing.$large) 0 0;
+
+  @include media-queries.mq($from: md) {
+    margin: 0 0 utils.rem(spacing.$large);
+  }
+
+  //override child panel margins
+  > * + * {
+    margin: 2rem 0 0;
+  }
+}

--- a/web/src/components/Storyblok/StoryblokRichText/StoryblokRichText.module.scss
+++ b/web/src/components/Storyblok/StoryblokRichText/StoryblokRichText.module.scss
@@ -30,7 +30,7 @@
   }
 
   //target lite youtube embed wrapper - (video) is hardcoded at the start of every title
-  article[data-title^='(video)'] {
+  [data-title^='(video)'] {
     margin: utils.rem(spacing.$large) 0 utils.rem(spacing.$x-large);
     //remove bottom margin to avoid increased vertical spacing
     &:last-child {
@@ -38,7 +38,7 @@
     }
   }
 
-  & :last-child {
+  &:last-child {
     margin-bottom: 0;
   }
 


### PR DESCRIPTION
- update styles to conform with style lint rules in CI.
- Add ignore to targeting BEM classes from DS PageHeader component when nested in News and Blog page components.

TODO: look at targeting h2 in RichText on infoPages

NOTE: discuss whether we need to add props to target each element within PageHeader in DS, allowing us to override styles to match designs. 
Or, do we remove the styles from News and Blog page components and just rely on what the DS gives us.