### PR TITLE
return null if author is string

### DIFF
--- a/web/src/components/Storyblok/News/NewsCard/NewsCard.tsx
+++ b/web/src/components/Storyblok/News/NewsCard/NewsCard.tsx
@@ -96,6 +96,10 @@ export const NewsCard: React.FC<NewsCardProps> = ({
 					{content.author && (
 						<div className={styles.author}>
 							{content.author.map((author: AuthorStoryblok) => {
+								if (typeof author === "string") {
+									return null;
+								}
+
 								const {
 									content: { name, jobTitle },
 									id,


### PR DESCRIPTION
- Issue with unresolved authors in homepage latestnews stories, causing error on render.
- Update newscard to handle author as string and return null