### PR TITLE
Nxt 459 replace next js links with anchors on storyblok related links component to avoid next web handling guidance detail routes

### DIFF
--- a/web/src/components/Storyblok/StoryblokButtonLink/StoryblokButtonLink.tsx
+++ b/web/src/components/Storyblok/StoryblokButtonLink/StoryblokButtonLink.tsx
@@ -19,9 +19,7 @@ export const StoryblokButtonLink: React.FC<StoryblokButtonLinkProps> = ({
 	const resolvedLink = resolveStoryblokLink(link as MultilinkStoryblok);
 	if (resolvedLink.url) {
 		linkType = resolvedLink.isInternal ? Link : undefined;
-		linkDestination = resolvedLink.isInternal
-			? `/${resolvedLink.url}`
-			: resolvedLink.url;
+		linkDestination = resolvedLink.url;
 	} else {
 		return undefined;
 	}

--- a/web/src/components/Storyblok/StoryblokRelatedLink/StoryblokRelatedLink.test.tsx
+++ b/web/src/components/Storyblok/StoryblokRelatedLink/StoryblokRelatedLink.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen } from "@testing-library/react";
+
+import { RelatedLinkStoryblok } from "@/types/storyblok";
+
+import { StoryblokRelatedLink } from "./StoryblokRelatedLink";
+
+const mockResourceLinkExternalLinkType: RelatedLinkStoryblok = {
+	_uid: "0were02",
+	link: {
+		id: "",
+		url: "https://nice.org.uk/guidance/ta10",
+		linktype: "url",
+		fieldtype: "multilink",
+		cached_url: "https://nice.org.uk/guidance/ta10",
+	},
+	title: "test link to guidance",
+	component: "relatedLink",
+};
+
+const mockResourceLinkStoryLinkType: RelatedLinkStoryblok = {
+	_uid: "86046",
+	link: {
+		id: "73000",
+		url: "",
+		linktype: "story",
+		fieldtype: "multilink",
+		cached_url: "about-us/our-charter",
+		story: {
+			name: "Our charter",
+			id: 907,
+			uuid: "730222",
+			slug: "our-charter",
+			url: "about-us/our-charter",
+			full_slug: "about-us/our-charter",
+			_stopResolving: true,
+		},
+	},
+	title: "internal link info page",
+	component: "relatedLink",
+};
+
+describe("StoryblokRelatedLink Component", () => {
+	// that the link renders with the correct title and href
+	it("should render the related link from an external source ", () => {
+		render(<StoryblokRelatedLink blok={mockResourceLinkExternalLinkType} />);
+
+		const link = screen.getByRole("link", {
+			name: mockResourceLinkExternalLinkType.title,
+		});
+		expect(link).toBeInTheDocument();
+		expect(link).toHaveAttribute(
+			"href",
+			mockResourceLinkExternalLinkType.link.url
+		);
+		expect(link).toHaveTextContent(mockResourceLinkExternalLinkType.title);
+	});
+
+	// it shows a leading / if the link is internal
+	it("should render the related link from an internal source", () => {
+		render(<StoryblokRelatedLink blok={mockResourceLinkStoryLinkType} />);
+
+		const link = screen.getByRole("link", {
+			name: mockResourceLinkStoryLinkType.title,
+		});
+		expect(link).toBeInTheDocument();
+		expect(link).toHaveAttribute(
+			"href",
+			`/${mockResourceLinkStoryLinkType.link.story.url}`
+		);
+		expect(link).toHaveTextContent(mockResourceLinkStoryLinkType.title);
+	});
+
+	it("should fall back to a cached url if the link is internal and the story url is not present", () => {
+		const mockInternalLinkWithoutStoryUrl = {
+			...mockResourceLinkStoryLinkType,
+			link: {
+				...mockResourceLinkStoryLinkType.link,
+				story: undefined,
+			},
+		};
+
+		render(<StoryblokRelatedLink blok={mockInternalLinkWithoutStoryUrl} />);
+		const link = screen.getByRole("link", {
+			name: mockInternalLinkWithoutStoryUrl.title,
+		});
+		expect(link).toBeInTheDocument();
+		expect(link).toHaveAttribute(
+			"href",
+			`/${mockInternalLinkWithoutStoryUrl.link.cached_url}`
+		);
+	});
+
+	// that the link does not render if the link href is not present from resolveStoryblokLink
+	it("should not render if the link url property is not present", () => {
+		const mockLinkWithoutUrl = {
+			...mockResourceLinkExternalLinkType,
+			link: {
+				...mockResourceLinkExternalLinkType.link,
+				url: "",
+				cached_url: "",
+			},
+		};
+
+		render(<StoryblokRelatedLink blok={mockLinkWithoutUrl} />);
+		const link = screen.queryByRole("link", {
+			name: mockLinkWithoutUrl.title,
+		});
+		expect(link).not.toBeInTheDocument();
+	});
+});

--- a/web/src/components/Storyblok/StoryblokRelatedLink/StoryblokRelatedLink.tsx
+++ b/web/src/components/Storyblok/StoryblokRelatedLink/StoryblokRelatedLink.tsx
@@ -1,22 +1,28 @@
 import React from "react";
 
 import { Link } from "@/components/Link/Link";
-import { RelatedLinkStoryblok } from "@/types/storyblok";
+import { MultilinkStoryblok, RelatedLinkStoryblok } from "@/types/storyblok";
 import { resolveStoryblokLink } from "@/utils/storyblok";
 
 export interface StoryblokRelatedLinkProps {
 	blok: RelatedLinkStoryblok;
 }
 
-export const StoryblokRelatedLink = ({
+export const StoryblokRelatedLink: React.FC<StoryblokRelatedLinkProps> = ({
 	blok,
-}: StoryblokRelatedLinkProps): React.ReactElement => {
+}: StoryblokRelatedLinkProps) => {
 	// TODO: check if we are handling to href props of the link component correctly
-	const resolvedLink = blok.link
-		? resolveStoryblokLink(blok.link).url
-		: undefined;
 
-	return (
-		<Link href={resolvedLink ? resolvedLink : blok.link.url}>{blok.title}</Link>
-	);
+	let Tag: React.ElementType;
+	let linkDestination = undefined;
+	const resolvedLink = resolveStoryblokLink(blok.link as MultilinkStoryblok);
+
+	if (resolvedLink.url) {
+		Tag = resolvedLink.isInternal ? Link : "a";
+		linkDestination = resolvedLink.url;
+	} else {
+		return undefined;
+	}
+
+	return <Tag href={linkDestination}>{blok.title}</Tag>;
 };

--- a/web/src/components/Storyblok/StoryblokRelatedNewsLink/StoryblokRelatedNewsLink.test.tsx
+++ b/web/src/components/Storyblok/StoryblokRelatedNewsLink/StoryblokRelatedNewsLink.test.tsx
@@ -5,14 +5,20 @@ import { RelatedNewsLinkStoryblok } from "@/types/storyblok";
 import { StoryblokRelatedNewsLink } from "./StoryblokRelatedNewsLink";
 
 const mockRelatedNewsLinkResponse: RelatedNewsLinkStoryblok = {
-	title: "Test title",
-	publisher: "Test publisher",
-	date: "2021-01-01",
+	_uid: "42dac477-17b6-4052-9025-16a24dc1a438",
+	date: "2024-05-09 12:00",
 	link: {
-		url: "https://www.google.com",
+		id: "",
+		url: "https://www.standard.co.uk/news/health/mark-chapman-nhs-wales-swansea-university-b1156651.html",
+		linktype: "url",
+		fieldtype: "multilink",
+		cached_url:
+			"https://www.standard.co.uk/news/health/mark-chapman-nhs-wales-swansea-university-b1156651.html",
 	},
-	_uid: "123",
+	title:
+		"Health watchdog backs wider use of breast cancer tumour profiling tests",
 	component: "relatedNewsLink",
+	publisher: "The Standard",
 };
 
 describe("StoryblokRelatedNewsLink Component", () => {
@@ -33,7 +39,7 @@ describe("StoryblokRelatedNewsLink Component", () => {
 	it("should render the date of the related news link", () => {
 		render(<StoryblokRelatedNewsLink blok={mockRelatedNewsLinkResponse} />);
 
-		const date = screen.getByText("1 January 2021");
+		const date = screen.getByText("9 May 2024");
 		expect(date).toBeInTheDocument();
 	});
 
@@ -44,5 +50,35 @@ describe("StoryblokRelatedNewsLink Component", () => {
 			name: mockRelatedNewsLinkResponse.title,
 		});
 		expect(link).toBeInTheDocument();
+	});
+
+	it("should handle internal links to news articles", () => {
+		const pathWithoutLeadingSlash = "news/articles/mark-chapman";
+		const mockInternalNewsLinkResponse: RelatedNewsLinkStoryblok = {
+			...mockRelatedNewsLinkResponse,
+			link: {
+				...mockRelatedNewsLinkResponse.link,
+				url: "",
+				linktype: "story",
+				cached_url: pathWithoutLeadingSlash,
+				story: {
+					name: "Mark Chapman",
+					id: 907,
+					uuid: "730222",
+					slug: "mark-chapman",
+					url: pathWithoutLeadingSlash,
+					full_slug: pathWithoutLeadingSlash,
+					_stopResolving: true,
+				},
+			},
+		};
+
+		render(<StoryblokRelatedNewsLink blok={mockInternalNewsLinkResponse} />);
+
+		const link = screen.getByRole("link", {
+			name: mockInternalNewsLinkResponse.title,
+		});
+		expect(link).toBeInTheDocument();
+		expect(link).toHaveAttribute("href", `/${pathWithoutLeadingSlash}`);
 	});
 });

--- a/web/src/pages/news/articles/__snapshots__/[slug].page.test.tsx.snap
+++ b/web/src/pages/news/articles/__snapshots__/[slug].page.test.tsx.snap
@@ -150,7 +150,7 @@ exports[`NewsArticlePage renders the page 1`] = `
               Associated guidance and resources
             </h2>
             <a
-              href="test-new-nc-2"
+              href="/test-new-nc-2"
             >
               Test related link 1
             </a>

--- a/web/src/utils/storyblok.test.ts
+++ b/web/src/utils/storyblok.test.ts
@@ -48,8 +48,22 @@ describe("Storyblok utils", () => {
 				{ url: "mailto:somebody@example.com", isInternal: false },
 			],
 			[
-				{ linktype: "story", url: "example/page/slug" },
-				{ url: "example/page/slug", isInternal: true },
+				{
+					linktype: "story",
+					url: "",
+					cached_url: "example/page/slug ",
+					story: { url: "example/page/slug ", full_slug: "example/page/slug" },
+				},
+				{ url: "/example/page/slug", isInternal: true },
+			],
+			[
+				{
+					linktype: "story",
+					url: "",
+					cached_url: "example/page/slug",
+					story: { url: "", full_slug: "example/page/slug" },
+				},
+				{ url: "/example/page/slug", isInternal: true },
 			],
 		])(
 			"should ensure that correct links are returned for each linktype",

--- a/web/src/utils/storyblok.ts
+++ b/web/src/utils/storyblok.ts
@@ -319,6 +319,7 @@ export const resolveStoryblokLink = ({
 	url,
 	cached_url,
 	email,
+	story,
 }: MultilinkStoryblok): { url: string | undefined; isInternal: boolean } => {
 	switch (linktype) {
 		case "url":
@@ -332,11 +333,13 @@ export const resolveStoryblokLink = ({
 				url: email?.trim() ? `mailto:${email.trim()}` : undefined,
 				isInternal: false,
 			};
-		case "story":
+		case "story": {
+			const resolvedUrl = story?.url.trim() || cached_url?.trim() || undefined;
 			return {
-				url: url?.trim() || cached_url?.trim() || undefined,
+				url: `/${resolvedUrl}`,
 				isInternal: true,
 			};
+		}
 		default:
 			return {
 				url: undefined,


### PR DESCRIPTION
Relates NXT-459 use anchor links to avoid next web handling guidance detail routes

- refactored storyblok util function resolveStoryblokLink.
- refactored components using resolveStoryblokLink.
- Refactored StoryblokRelatedLink component to accommodate internal and external links.  Now uses anchor links to external guidance pages
