### PR TITLE
NXT-751-NXT-752-add-missing-redirects-and-remove-bnf-redirects

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -587,6 +587,12 @@ const nextConfig = {
 			},
 			{
 				source:
+					"/about/what-we-do/our-programmes/nice-guidance/interventional-procedures-guidance/timeline",
+				destination: "/process/pmg28/chapter/introduction",
+				permanent: true,
+			},
+			{
+				source:
 					"/about/what-we-do/our-programmes/nice-guidance/nice-guidelines/nice-medicines-practice-guidelines",
 				destination:
 					"/what-nice-does/our-guidance/about-nice-guidelines/how-we-develop-nice-guidelines",


### PR DESCRIPTION
https://nicedigital.atlassian.net/browse/NXT-751
https://nicedigital.atlassian.net/browse/NXT-752

### Acceptance Criteria
1. BNF & BNFC UK Only redirects are removed from the repo
2. There is no code relating to the BNF & BNFC UK only pages remaining in the NextWeb repo
3. New redirects function as expected
    a. `/about/what-we-do/our-programmes/nice-guidance/nice-technology-appraisal-guidance/changes-to-health-technology-evaluation` redirects to
`/what-nice-does/our-guidance/about-technology-appraisal-guidance/our-methods-and-processes-health-technology-evaluation-manual`
    b. `/about/what-we-do/our-programmes/nice-guidance/interventional-procedures-guidance/timeline` redirects to
`/process/pmg28/chapter/introduction`
4. Existing Changes to Health Technology Evaluation redirect continues to function as expected (`/about/what-we-do/our-programmes/nice-guidance/nice-about-technology-appraisal-guidance/changes-to-health-technology-evaluation` redirects to `/what-nice-does/our-guidance/about-technology-appraisal-guidance/our-methods-and-processes-health-technology-evaluation-manual`)